### PR TITLE
avoid usingnamespace

### DIFF
--- a/src/c.zig
+++ b/src/c.zig
@@ -1,4 +1,4 @@
-pub usingnamespace @cImport({
+pub const c = @cImport({
     @cInclude("glslang/Include/glslang_c_interface.h");
     @cInclude("glslang/Public/resource_limits_c.h");
     @cInclude("glslang/SPIRV/spv_remapper_c_interface.h");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const structopt = @import("structopt");
 const log = std.log.scoped(.shader_compiler);
-const c = @import("c.zig");
+const c = @import("c.zig").c;
 const assert = std.debug.assert;
 
 const Allocator = std.mem.Allocator;


### PR DESCRIPTION
Zig is planning to remove `@cImport` as well at which point this translate-c task will need to move to the build system.

Avoiding `usingnamespace` allows using the experimental `-fincremental` compiler feature.