### PR TITLE
--optimize-size instead of --optimize-small in zig build example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ switch (optimize) {
     }),
     .ReleaseSmall => compile_shader.addArgs(&.{
         "--optimize-perf",
-        "--optimize-small",
+        "--optimize-size",
     }),
 }
 compile_shader.addFileArg(b.path(path));


### PR DESCRIPTION
In the shader_compiler code and the output of `shader_compiler --help` this arg is called `--optimize-size`, but in the readme it is called `--optimize-small`.