### PR TITLE
Fix: update deprecated u29 usage to std.mem.Alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A command line tool that compiles GLSL shaders to SPIRV, and optimizes them usin
 
 Remap is also supported (results in better compression), SPIRV is validated before results are written.
 
+# Zig Version
+
+[`main`](https://github.com/Games-by-Mason/shader_compiler/tree/main) loosely tracks Zig master. For support for Zig 0.14.0, use [v1.0.0](https://github.com/Games-by-Mason/shader_compiler/releases/tag/v0.1.0).
+
 # Usage
 
 Note that the initial compile will take quite while as it's building the shader C++ implementation of the shader compiler. Once this finishes it will be cached.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .shader_compiler,
     .fingerprint = 0x36d3f5d96a6ce56c,
     .version = "0.0.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0-dev.383+927f233ff",
     .dependencies = .{
         .glslang = .{
             .url = "https://github.com/Games-by-Mason/glslang-zig/archive/4d2877072dc0ebb97698e6620a59e55ef3f367ce.tar.gz",

--- a/src/root.zig
+++ b/src/root.zig
@@ -230,7 +230,7 @@ fn readSource(
     };
     defer file.close();
 
-    return file.readToEndAllocOptions(gpa, max_file_len, null, 1, 0) catch |err| {
+    return file.readToEndAllocOptions(gpa, max_file_len, null, .@"1", 0) catch |err| {
         log.err("{s}: {s}", .{ path, @errorName(err) });
         std.process.exit(1);
     };
@@ -815,7 +815,7 @@ const Callbacks = struct {
             self.gpa,
             max_file_len,
             null,
-            1,
+            .@"1",
             0,
         ) catch |err| cppPanic(@errorName(err));
         result.* = .{


### PR DESCRIPTION
Zig commit [`f32a5d3`](https://github.com/ziglang/zig/commit/f32a5d349d2c359a2a1f627aa70e1a7a6f6330ea) deprecated `u29` and replaced it with `std.mem.Alignment`.

This change updates the library to follow the new alignment API. It replaces two instances of `1` (previously implicitly a `u29`) with `@as(std.mem.Alignment, .One)` to match the updated Zig standard.